### PR TITLE
replace div_for with content_tag

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,4 @@
-<%= div_for(comment) do %>
+<%= content_tag :div, class: "comment" do %>
 	<div class="comments_wrapper clearfix">
 		<div class="pull-left">
 			<p class="lead"><%= comment.body %></p>


### PR DESCRIPTION
In Rails 5.1 content_tag_for and div_for have been removed in favor of just using content_tag.